### PR TITLE
fix: optimise Is* and As* to reduce allocations

### DIFF
--- a/faults.go
+++ b/faults.go
@@ -36,6 +36,17 @@ var (
 
 	// Unimplemented indicates the operation is not implemented or not supported
 	Unimplemented error = &UnimplementedFailure{}
+
+	// Singleton instances for Is* functions to avoid allocations
+	permissionFailureInstance     = &PermissionFailure{}
+	authenticationFailureInstance = &AuthenticationFailure{}
+	missingFailureInstance        = &MissingFailure{}
+	badRequestInstance            = &BadRequest{}
+	preconditionFailureInstance   = &PreconditionFailure{}
+	conflictFailureInstance       = &ConflictFailure{}
+	availabilityFailureInstance   = &AvailabilityFailure{}
+	quotaFailureInstance          = &QuotaFailure{}
+	unimplementedFailureInstance  = &UnimplementedFailure{}
 )
 
 // WithPermissionDenied wraps `parent` with a `PermissionFailure`
@@ -141,43 +152,43 @@ func ResourceExhausted(violations ...*QuotaViolation) error {
 }
 
 func IsPermissionDenied(err error) bool {
-	return errors.Is(err, &PermissionFailure{})
+	return errors.Is(err, permissionFailureInstance)
 }
 
 func IsUnauthenticated(err error) bool {
-	return errors.Is(err, &AuthenticationFailure{})
+	return errors.Is(err, authenticationFailureInstance)
 }
 
 func IsNotFound(err error) bool {
-	return errors.Is(err, &MissingFailure{})
+	return errors.Is(err, missingFailureInstance)
 }
 
 func IsBad(err error) bool {
-	return errors.Is(err, &BadRequest{})
+	return errors.Is(err, badRequestInstance)
 }
 
 func IsFailedPrecondition(err error) bool {
-	return errors.Is(err, &PreconditionFailure{})
+	return errors.Is(err, preconditionFailureInstance)
 }
 
 func IsAborted(err error) bool {
-	return errors.Is(err, &ConflictFailure{})
+	return errors.Is(err, conflictFailureInstance)
 }
 
 func IsUnavailable(err error) bool {
-	return errors.Is(err, &AvailabilityFailure{})
+	return errors.Is(err, availabilityFailureInstance)
 }
 
 func IsResourceExhausted(err error) bool {
-	return errors.Is(err, &QuotaFailure{})
+	return errors.Is(err, quotaFailureInstance)
 }
 
 func IsUnimplemented(err error) bool {
-	return errors.Is(err, &UnimplementedFailure{})
+	return errors.Is(err, unimplementedFailureInstance)
 }
 
 func AsPermissionDenied(err error) (*PermissionFailure, bool) {
-	e := &PermissionFailure{}
+	var e *PermissionFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -185,7 +196,7 @@ func AsPermissionDenied(err error) (*PermissionFailure, bool) {
 }
 
 func AsUnauthenticated(err error) (*AuthenticationFailure, bool) {
-	e := &AuthenticationFailure{}
+	var e *AuthenticationFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -193,7 +204,7 @@ func AsUnauthenticated(err error) (*AuthenticationFailure, bool) {
 }
 
 func AsNotFound(err error) (*MissingFailure, bool) {
-	e := &MissingFailure{}
+	var e *MissingFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -201,7 +212,7 @@ func AsNotFound(err error) (*MissingFailure, bool) {
 }
 
 func AsBad(err error) (*BadRequest, bool) {
-	e := &BadRequest{}
+	var e *BadRequest
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -209,7 +220,7 @@ func AsBad(err error) (*BadRequest, bool) {
 }
 
 func AsFailedPrecondition(err error) (*PreconditionFailure, bool) {
-	e := &PreconditionFailure{}
+	var e *PreconditionFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -217,7 +228,7 @@ func AsFailedPrecondition(err error) (*PreconditionFailure, bool) {
 }
 
 func AsAborted(err error) (*ConflictFailure, bool) {
-	e := &ConflictFailure{}
+	var e *ConflictFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -225,7 +236,7 @@ func AsAborted(err error) (*ConflictFailure, bool) {
 }
 
 func AsUnavailable(err error) (*AvailabilityFailure, bool) {
-	e := &AvailabilityFailure{}
+	var e *AvailabilityFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -233,7 +244,7 @@ func AsUnavailable(err error) (*AvailabilityFailure, bool) {
 }
 
 func AsResourceExhausted(err error) (*QuotaFailure, bool) {
-	e := &QuotaFailure{}
+	var e *QuotaFailure
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -241,7 +252,7 @@ func AsResourceExhausted(err error) (*QuotaFailure, bool) {
 }
 
 func AsUnimplemented(err error) (*UnimplementedFailure, bool) {
-	e := &UnimplementedFailure{}
+	var e *UnimplementedFailure
 	if errors.As(err, &e) {
 		return e, true
 	}

--- a/faults_bench_test.go
+++ b/faults_bench_test.go
@@ -1,0 +1,404 @@
+package faults_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/deixis/faults"
+)
+
+var (
+	// Pre-created errors for benchmarking
+	errBase            = errors.New("base error")
+	permissionErr      = faults.WithPermissionDenied(errBase)
+	unauthenticatedErr = faults.WithUnauthenticated(errBase)
+	notFoundErr        = faults.WithNotFound(errBase)
+	badErr             = faults.WithBad(errBase, &faults.FieldViolation{Field: "test", Description: "invalid"})
+	preconditionErr    = faults.WithFailedPrecondition(errBase, &faults.PreconditionViolation{Type: "test", Subject: "test", Description: "failed"})
+	abortedErr         = faults.WithAborted(errBase, &faults.ConflictViolation{Resource: "test", Description: "conflict"})
+	unavailableErr     = faults.WithUnavailable(errBase, time.Second)
+	exhaustedErr       = faults.WithResourceExhausted(errBase, &faults.QuotaViolation{Subject: "test", Description: "exhausted"})
+	unimplementedErr   = faults.WithUnimplemented(errBase)
+
+	// Sink variables to prevent compiler optimizations
+	resultError  error
+	resultBool   bool
+	resultString string
+)
+
+// Benchmark With* functions
+func BenchmarkWithPermissionDenied(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithPermissionDenied(errBase)
+	}
+}
+
+func BenchmarkWithUnauthenticated(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithUnauthenticated(errBase)
+	}
+}
+
+func BenchmarkWithNotFound(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithNotFound(errBase)
+	}
+}
+
+func BenchmarkWithBad(b *testing.B) {
+	violation := &faults.FieldViolation{Field: "test", Description: "invalid"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithBad(errBase, violation)
+	}
+}
+
+func BenchmarkWithFailedPrecondition(b *testing.B) {
+	violation := &faults.PreconditionViolation{Type: "test", Subject: "test", Description: "failed"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithFailedPrecondition(errBase, violation)
+	}
+}
+
+func BenchmarkWithAborted(b *testing.B) {
+	violation := &faults.ConflictViolation{Resource: "test", Description: "conflict"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithAborted(errBase, violation)
+	}
+}
+
+func BenchmarkWithUnavailable(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithUnavailable(errBase, time.Second)
+	}
+}
+
+func BenchmarkWithResourceExhausted(b *testing.B) {
+	violation := &faults.QuotaViolation{Subject: "test", Description: "exhausted"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithResourceExhausted(errBase, violation)
+	}
+}
+
+func BenchmarkWithUnimplemented(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultError = faults.WithUnimplemented(errBase)
+	}
+}
+
+// Benchmark constructor functions
+func BenchmarkBad(b *testing.B) {
+	violation := &faults.FieldViolation{Field: "test", Description: "invalid"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.Bad(violation)
+	}
+}
+
+func BenchmarkFailedPrecondition(b *testing.B) {
+	violation := &faults.PreconditionViolation{Type: "test", Subject: "test", Description: "failed"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.FailedPrecondition(violation)
+	}
+}
+
+func BenchmarkAborted(b *testing.B) {
+	violation := &faults.ConflictViolation{Resource: "test", Description: "conflict"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.Aborted(violation)
+	}
+}
+
+func BenchmarkUnavailable(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultError = faults.Unavailable(time.Second)
+	}
+}
+
+func BenchmarkResourceExhausted(b *testing.B) {
+	violation := &faults.QuotaViolation{Subject: "test", Description: "exhausted"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultError = faults.ResourceExhausted(violation)
+	}
+}
+
+// Benchmark Is* functions
+func BenchmarkIsPermissionDenied(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsPermissionDenied(permissionErr)
+	}
+}
+
+func BenchmarkIsUnauthenticated(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsUnauthenticated(unauthenticatedErr)
+	}
+}
+
+func BenchmarkIsNotFound(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsNotFound(notFoundErr)
+	}
+}
+
+func BenchmarkIsBad(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsBad(badErr)
+	}
+}
+
+func BenchmarkIsFailedPrecondition(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsFailedPrecondition(preconditionErr)
+	}
+}
+
+func BenchmarkIsAborted(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsAborted(abortedErr)
+	}
+}
+
+func BenchmarkIsUnavailable(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsUnavailable(unavailableErr)
+	}
+}
+
+func BenchmarkIsResourceExhausted(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsResourceExhausted(exhaustedErr)
+	}
+}
+
+func BenchmarkIsUnimplemented(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsUnimplemented(unimplementedErr)
+	}
+}
+
+// Benchmark As* functions
+func BenchmarkAsPermissionDenied(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsPermissionDenied(permissionErr)
+	}
+}
+
+func BenchmarkAsUnauthenticated(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsUnauthenticated(unauthenticatedErr)
+	}
+}
+
+func BenchmarkAsNotFound(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsNotFound(notFoundErr)
+	}
+}
+
+func BenchmarkAsBad(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsBad(badErr)
+	}
+}
+
+func BenchmarkAsFailedPrecondition(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsFailedPrecondition(preconditionErr)
+	}
+}
+
+func BenchmarkAsAborted(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsAborted(abortedErr)
+	}
+}
+
+func BenchmarkAsUnavailable(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsUnavailable(unavailableErr)
+	}
+}
+
+func BenchmarkAsResourceExhausted(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsResourceExhausted(exhaustedErr)
+	}
+}
+
+func BenchmarkAsUnimplemented(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsUnimplemented(unimplementedErr)
+	}
+}
+
+// Benchmark Error() methods for each failure type
+func BenchmarkAvailabilityFailureError(b *testing.B) {
+	err := faults.Unavailable(time.Second)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkQuotaFailureError(b *testing.B) {
+	violation := &faults.QuotaViolation{Subject: "test", Description: "exhausted"}
+	err := faults.ResourceExhausted(violation)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkPreconditionFailureError(b *testing.B) {
+	violation := &faults.PreconditionViolation{Type: "test", Subject: "test", Description: "failed"}
+	err := faults.FailedPrecondition(violation)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkBadRequestError(b *testing.B) {
+	violation := &faults.FieldViolation{Field: "test", Description: "invalid"}
+	err := faults.Bad(violation)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkConflictFailureError(b *testing.B) {
+	violation := &faults.ConflictViolation{Resource: "test", Description: "conflict"}
+	err := faults.Aborted(violation)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkMissingFailureError(b *testing.B) {
+	err := faults.NotFound
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkPermissionFailureError(b *testing.B) {
+	err := faults.PermissionDenied
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkAuthenticationFailureError(b *testing.B) {
+	err := faults.Unauthenticated
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkUnimplementedFailureError(b *testing.B) {
+	err := faults.Unimplemented
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = err.Error()
+	}
+}
+
+// Benchmark String() methods for violation types
+func BenchmarkQuotaViolationString(b *testing.B) {
+	violation := &faults.QuotaViolation{Subject: "clientip:192.168.1.1", Description: "Daily limit exceeded"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = violation.String()
+	}
+}
+
+func BenchmarkPreconditionViolationString(b *testing.B) {
+	violation := &faults.PreconditionViolation{Type: "TOS", Subject: "google.com/cloud", Description: "Terms of service not accepted"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = violation.String()
+	}
+}
+
+func BenchmarkFieldViolationString(b *testing.B) {
+	violation := &faults.FieldViolation{Field: "field_violations.field", Description: "Invalid field value"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = violation.String()
+	}
+}
+
+func BenchmarkConflictViolationString(b *testing.B) {
+	violation := &faults.ConflictViolation{Resource: "user:123e4567-e89b-12d3-a456-426614174000", Description: "Resource is locked"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultString = violation.String()
+	}
+}
+
+// Benchmark complex scenarios with multiple violations
+func BenchmarkBadRequestWithMultipleViolations(b *testing.B) {
+	violations := []*faults.FieldViolation{
+		{Field: "name", Description: "Name is required"},
+		{Field: "email", Description: "Invalid email format"},
+		{Field: "age", Description: "Age must be positive"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := faults.Bad(violations...)
+		resultString = err.Error()
+	}
+}
+
+func BenchmarkQuotaFailureWithMultipleViolations(b *testing.B) {
+	violations := []*faults.QuotaViolation{
+		{Subject: "clientip:192.168.1.1", Description: "Daily API limit exceeded"},
+		{Subject: "project:my-project", Description: "Storage quota exceeded"},
+		{Subject: "user:john@example.com", Description: "Request rate limit exceeded"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := faults.ResourceExhausted(violations...)
+		resultString = err.Error()
+	}
+}
+
+// Benchmark error wrapping scenarios
+func BenchmarkNestedErrorWrapping(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		err := errors.New("original error")
+		err = faults.WithNotFound(err)
+		err = faults.WithUnauthenticated(err)
+		resultString = err.Error()
+	}
+}
+
+// Benchmark Is/As functions with non-matching errors
+func BenchmarkIsNotFoundWithWrongError(b *testing.B) {
+	wrongErr := faults.PermissionDenied
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultBool = faults.IsNotFound(wrongErr)
+	}
+}
+
+func BenchmarkAsNotFoundWithWrongError(b *testing.B) {
+	wrongErr := faults.PermissionDenied
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, resultBool = faults.AsNotFound(wrongErr)
+	}
+}

--- a/faults_test.go
+++ b/faults_test.go
@@ -1,6 +1,7 @@
 package faults_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/deixis/faults"
@@ -43,6 +44,10 @@ func TestIs(t *testing.T) {
 		},
 		{
 			Error: faults.ResourceExhausted(),
+			Is:    faults.IsResourceExhausted,
+		},
+		{
+			Error: fmt.Errorf("wrapped: %w", faults.ResourceExhausted()),
 			Is:    faults.IsResourceExhausted,
 		},
 	}
@@ -112,6 +117,13 @@ func TestAs(t *testing.T) {
 		},
 		{
 			Error: faults.ResourceExhausted(),
+			As: func(err error) bool {
+				_, ok := faults.AsResourceExhausted(err)
+				return ok
+			},
+		},
+		{
+			Error: fmt.Errorf("wrapped: %w", faults.ResourceExhausted()),
 			As: func(err error) bool {
 				_, ok := faults.AsResourceExhausted(err)
 				return ok


### PR DESCRIPTION
This rework the `Is` and `As` helper functions to reduce or remove memory allocation.

## Comparison

### Is*

| Function | Before | After | Speed Improvement | Memory Reduction | Allocation Reduction |
|----------|--------|-------|-------------------|------------------|---------------------|
| `IsPermissionDenied` | 25.69 ns/op, 16 B/op, 1 allocs/op | 6.67 ns/op, 0 B/op, 0 allocs/op | **3.8x faster** | **100%** | **100%** |
| `IsUnauthenticated` | 25.11 ns/op, 16 B/op, 1 allocs/op | 6.46 ns/op, 0 B/op, 0 allocs/op | **3.9x faster** | **100%** | **100%** |
| `IsNotFound` | 24.97 ns/op, 16 B/op, 1 allocs/op | 6.44 ns/op, 0 B/op, 0 allocs/op | **3.9x faster** | **100%** | **100%** |
| `IsBad` | 29.68 ns/op, 48 B/op, 1 allocs/op | 7.52 ns/op, 0 B/op, 0 allocs/op | **3.9x faster** | **100%** | **100%** |
| `IsFailedPrecondition` | 29.66 ns/op, 48 B/op, 1 allocs/op | 6.64 ns/op, 0 B/op, 0 allocs/op | **4.5x faster** | **100%** | **100%** |
| `IsAborted` | 30.16 ns/op, 48 B/op, 1 allocs/op | 6.45 ns/op, 0 B/op, 0 allocs/op | **4.7x faster** | **100%** | **100%** |
| `IsUnavailable` | 27.14 ns/op, 24 B/op, 1 allocs/op | 6.56 ns/op, 0 B/op, 0 allocs/op | **4.1x faster** | **100%** | **100%** |
| `IsResourceExhausted` | 31.34 ns/op, 48 B/op, 1 allocs/op | 6.46 ns/op, 0 B/op, 0 allocs/op | **4.9x faster** | **100%** | **100%** |
| `IsUnimplemented` | 25.20 ns/op, 16 B/op, 1 allocs/op | 6.51 ns/op, 0 B/op, 0 allocs/op | **3.9x faster** | **100%** | **100%** |

### As*

| Function | Before | After | Speed Improvement | Memory Reduction | Allocation Reduction |
|----------|--------|-------|-------------------|------------------|---------------------|
| `AsPermissionDenied` | 75.67 ns/op, 24 B/op, 2 allocs/op | 55.02 ns/op, 8 B/op, 1 allocs/op | **1.4x faster** | **67%** | **50%** |
| `AsUnauthenticated` | 77.50 ns/op, 24 B/op, 2 allocs/op | 55.34 ns/op, 8 B/op, 1 allocs/op | **1.4x faster** | **67%** | **50%** |
| `AsNotFound` | 75.80 ns/op, 24 B/op, 2 allocs/op | 55.36 ns/op, 8 B/op, 1 allocs/op | **1.4x faster** | **67%** | **50%** |
| `AsBad` | 83.31 ns/op, 56 B/op, 2 allocs/op | 55.30 ns/op, 8 B/op, 1 allocs/op | **1.5x faster** | **86%** | **50%** |
| `AsFailedPrecondition` | 82.36 ns/op, 56 B/op, 2 allocs/op | 55.64 ns/op, 8 B/op, 1 allocs/op | **1.5x faster** | **86%** | **50%** |
| `AsAborted` | 83.82 ns/op, 56 B/op, 2 allocs/op | 55.21 ns/op, 8 B/op, 1 allocs/op | **1.5x faster** | **86%** | **50%** |
| `AsUnavailable` | 85.54 ns/op, 32 B/op, 2 allocs/op | 56.48 ns/op, 8 B/op, 1 allocs/op | **1.5x faster** | **75%** | **50%** |
| `AsResourceExhausted` | 82.19 ns/op, 56 B/op, 2 allocs/op | 55.30 ns/op, 8 B/op, 1 allocs/op | **1.5x faster** | **86%** | **50%** |
| `AsUnimplemented` | 75.35 ns/op, 24 B/op, 2 allocs/op | 55.30 ns/op, 8 B/op, 1 allocs/op | **1.4x faster** | **67%** | **50%** |

## Technical Details

### Is* Functions Optimization
```go
// Before
func IsPermissionDenied(err error) bool {
    return errors.Is(err, &PermissionFailure{})  // Allocates every call
}

// After  
func IsPermissionDenied(err error) bool {
    return errors.Is(err, permissionFailureInstance)  // Reuses singleton
}
```

### As* Functions Optimization
```go
// Before
func AsPermissionDenied(err error) (*PermissionFailure, bool) {
    e := &PermissionFailure{}  // Unnecessary allocation
    if errors.As(err, &e) {
        return e, true
    }
    return nil, false
}

// After
func AsPermissionDenied(err error) (*PermissionFailure, bool) {
    var e *PermissionFailure  // No allocation, starts as nil
    if errors.As(err, &e) {
        return e, true
    }
    return nil, false
}
```
