### PR TITLE
fix: correct README examples and add missing godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This error indicates that the request does not have valid authentication credent
 func SensitiveOperation(ctx context.Context) error {
   user, ok := user.FromContext(ctx)
   if !ok {
-    return nil, faults.Unauthenticated
+    return faults.Unauthenticated
   }
 
   // Perform operation
@@ -147,10 +147,10 @@ It must not be used for rejections caused by exhausting some resource. It must a
 func SensitiveResource(ctx context.Context) error {
   user, ok := user.FromContext(ctx)
   if !ok {
-    return nil, faults.Unauthenticated
+    return faults.Unauthenticated
   }
   if !user.IsAdmin() {
-    return nil, faults.PermissionDenied
+    return faults.PermissionDenied
   }
 
   // Perform operation

--- a/faults.go
+++ b/faults.go
@@ -89,6 +89,7 @@ func WithResourceExhausted(parent error, violations ...*QuotaViolation) error {
 	return &QuotaFailure{parent, violations}
 }
 
+// WithUnimplemented wraps `parent` with an `UnimplementedFailure`
 func WithUnimplemented(parent error) error {
 	return &UnimplementedFailure{parent}
 }


### PR DESCRIPTION
## Summary

- Fix two README code examples that used `return nil, faults.Unauthenticated` / `return nil, faults.PermissionDenied` inside functions with a single `error` return type — these would not compile
- Add missing doc comment on `WithUnimplemented`, the only `With*` function without one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: fixes two non-compiling README snippets and adds a missing GoDoc comment, with no runtime behavior changes.
> 
> **Overview**
> Fixes the README `Authentication` and `Permission` examples to return a single `error` (removing the invalid `return nil, ...` pattern).
> 
> Adds the missing GoDoc comment for `WithUnimplemented` to match the other `With*` helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91abab7b26ccdf8bc44ec6a4ececb34dab457786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->